### PR TITLE
Add missing repo field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,9 @@
     "intelli-espower-loader": "^1.0.1",
     "mocha": "^2.4.5",
     "power-assert": "^1.2.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/teppeis/whilst.git"
   }
 }


### PR DESCRIPTION
Just a PR to fill in the missing repo field. The module is a big help though. Thanks!